### PR TITLE
Document SKILL.md requirements for Claude skill

### DIFF
--- a/.claude/skills/markdown-task-manager/SKILL.md
+++ b/.claude/skills/markdown-task-manager/SKILL.md
@@ -1,8 +1,9 @@
+---
+name: markdown-task-manager
+description: Use when managing tasks, the system is a Kanban task manager based on local Markdown files (`kanban.md` and `archive.md`). It follows a strict format compatible with the task-manager.html web application.
+---
+
 # 📋 Markdown Task Manager Skill
-
-## Description
-
-This skill manages a Kanban task system based on local Markdown files (`kanban.md` and `archive.md`). It follows a strict format compatible with the task-manager.html web application.
 
 ## When to Use This Skill
 

--- a/README.md
+++ b/README.md
@@ -276,12 +276,12 @@ cp CLAUDE.md.exemple your-project/CLAUDE.md
 
 **For Claude Code (CLI)**: A dedicated skill is available!
 ```bash
-# Copy the skill to your global Claude Code configuration
-cp .claude/skills/markdown-task-manager.md ~/.claude/skills/
+# Copy the skill directory (metadata lives in SKILL.md)
+cp -R .claude/skills/markdown-task-manager ~/.claude/skills/
 # Restart Claude Code to activate the skill
 ```
 
-The `markdown-task-manager` skill enables Claude Code to automatically manage your tasks with the required strict format. Once installed globally, it's available across all your projects.
+Claude Code reads the `SKILL.md` metadata inside this directory, which is why the whole folder must be copied. The `markdown-task-manager` skill enables Claude Code to automatically manage your tasks with the required strict format. Once installed globally, it's available across all your projects.
 
 **Using the Claude Code skill:**
 Once the skill is installed and Claude Code is restarted, the skill will automatically detect projects containing `kanban.md` and `archive.md`. You can simply ask:

--- a/readmeFR.md
+++ b/readmeFR.md
@@ -274,12 +274,12 @@ cp CLAUDE.md.exemple votre-projet/CLAUDE.md
 
 **Pour Claude Code (CLI)** : Un skill dédié est disponible !
 ```bash
-# Copier le skill dans votre configuration globale Claude Code
-cp .claude/skills/markdown-task-manager.md ~/.claude/skills/
+# Copier le dossier du skill (le metadata est dans SKILL.md)
+cp -R .claude/skills/markdown-task-manager ~/.claude/skills/
 # Redémarrer Claude Code pour activer le skill
 ```
 
-Le skill `markdown-task-manager` permet à Claude Code de gérer automatiquement vos tâches avec le format strict requis. Une fois installé globalement, il est disponible sur tous vos projets.
+Claude Code lit les métadonnées dans `SKILL.md`, d'où la nécessité de copier tout le dossier. Le skill `markdown-task-manager` permet à Claude Code de gérer automatiquement vos tâches avec le format strict requis. Une fois installé globalement, il est disponible sur tous vos projets.
 
 **Utilisation du skill Claude Code :**
 Une fois le skill installé et Claude Code redémarré, le skill détectera automatiquement les projets contenant `kanban.md` et `archive.md`. Vous pouvez simplement demander :


### PR DESCRIPTION
## Summary
- ensure the markdown-task-manager skill includes SKILL.md metadata so Claude Code can load it
- tell English and French readers to copy the entire skill directory so SKILL.md is installed